### PR TITLE
Switch to `@babel/runtime-corejs2` and latest Babel 7 release candidate.

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -19,7 +19,7 @@ module.exports = {
     [
       '@babel/transform-runtime',
       {
-        polyfill: false,
+        corejs: 2,
         regenerator: false
       }
     ]

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "node": ">=6.10"
   },
   "dependencies": {
-    "@babel/runtime": "^7.0.0-beta.40",
+    "@babel/runtime-corejs2": "^7.0.0-rc.1",
     "busboy": "^0.2.14",
     "object-path": "^0.11.4"
   },
@@ -40,10 +40,10 @@
     "graphql": "^0.13.1"
   },
   "devDependencies": {
-    "@babel/cli": "^7.0.0-beta.40",
-    "@babel/core": "^7.0.0-beta.40",
-    "@babel/plugin-transform-runtime": "^7.0.0-beta.40",
-    "@babel/preset-env": "^7.0.0-beta.40",
+    "@babel/cli": "^7.0.0-rc.1",
+    "@babel/core": "^7.0.0-rc.1",
+    "@babel/plugin-transform-runtime": "^7.0.0-rc.1",
+    "@babel/preset-env": "^7.0.0-rc.1",
     "ava": "^1.0.0-beta.3",
     "cross-env": "^5.1.3",
     "eslint": "^4.18.2",


### PR DESCRIPTION
After a change to `babel-plugin-transform-regenerator` in `@babel/*@beta.56`
(as seen in the reference link below) the `core-js` modules are no longer
included in `@babel/runtime` but are instead packaged into a new runtime
package: `@babel/runtime-corejs2`.  This makes the appropriate changes for
that to happen and switches minimum Babel versions to the latest 7.0 RC.

Ref: https://github.com/babel/babel/releases/tag/v7.0.0-beta.56
Ref: https://github.com/jaydenseric/apollo-upload-server/issues/103
Ref: https://github.com/apollographql/apollo-server/issues/1542