### PR TITLE
fix: Handle and reject parsing errors

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+package-malformed.json

--- a/package-malformed.json
+++ b/package-malformed.json
@@ -1,0 +1,31 @@
+{
+  "name": "@apollographql/apollo-upload-server",
+  "version": "5.0.3",
+  "description": "Enhances Apollo GraphQL Server for intuitive file uploads via GraphQL mutations.",
+  "license": "MIT",
+  "author": "opensource@apollographql.com",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/apollographql/apollo-upload-server.git"
+  },
+  "homepage": "https://github.com/apollographql/apollo-upload-server#readme",
+  "bugs": "https://github.com/apollographql/apollo-upload-server/issues",
+  "keywords": [
+    "apollo",
+    "server",
+    "graphql",
+    "file",
+    "upload",
+    "multipart",
+    "koa",
+    "express"
+  ],
+  "files": [
+    "lib"
+  ],
+  "main": "lib",
+  "module": "lib/index.mjs",
+  "engines": {
+    "node": ">=6.10"
+  },
+

--- a/src/errors.mjs
+++ b/src/errors.mjs
@@ -25,3 +25,4 @@ export class FilesBeforeMapUploadError extends UploadError {}
 export class FileMissingUploadError extends UploadError {}
 export class UploadPromiseDisconnectUploadError extends UploadError {}
 export class FileStreamDisconnectUploadError extends UploadError {}
+export class FileParsingError extends UploadError {}

--- a/src/middleware.mjs
+++ b/src/middleware.mjs
@@ -8,7 +8,8 @@ import {
   FilesBeforeMapUploadError,
   FileMissingUploadError,
   UploadPromiseDisconnectUploadError,
-  FileStreamDisconnectUploadError
+  FileStreamDisconnectUploadError,
+  FileParsingError
 } from './errors'
 
 class Upload {
@@ -116,9 +117,8 @@ export const processRequest = (
           mimetype,
           encoding
         })
-      else
-        // Discard the unexpected file.
-        stream.resume()
+      // Discard the unexpected file.
+      else stream.resume()
     })
 
     parser.once('filesLimit', () => {
@@ -137,6 +137,14 @@ export const processRequest = (
             upload.reject(
               new FileMissingUploadError('File missing in the request.')
             )
+    })
+
+    parser.once('error', () => {
+      return reject(
+        new FileParsingError(
+          'File uploads are malformed or could not be parsed.'
+        )
+      )
     })
 
     request.on('close', () => {


### PR DESCRIPTION
This prevents upstream servers from crashing when busboy can't parse a
form body.

I added a test, but it seems like the tests are broken or they all fail with or without this new code added. If I missed something, please let me know.

From my local testing, however, this works as expected and the app no longer crashes upon failed parsing on a multipart request.

Thanks!