### PR TITLE
chore: allow graphql v14 as peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "node": ">=8.5"
   },
   "peerDependencies": {
-    "graphql": "^0.13.1"
+    "graphql": "^0.13.1 || ^14.0.0"
   },
   "dependencies": {
     "busboy": "^0.2.14",


### PR DESCRIPTION
Most other libraries have been graphql v14 compatible. This is one of the few remaining pieces that cause warnings.